### PR TITLE
Fix game_id and season_id symbols

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -16,8 +16,8 @@ class Game
               :venue_time_zone_tz
 
   def initialize(row)
-    @game_id      = row[:game_id].to_sym
-    @season       = row[:season].to_sym
+    @game_id      = row[:game_id].to_i.to_sym
+    @season       = row[:season].to_i.to_sym
     @type         = row[:type]
     @date_time    = row[:date_time]
     @away_team_id = row[:away_team_id]


### PR DESCRIPTION
Did .to_i.to_sym to take quotation marks out of symbol names.