### PR TITLE
Debug worst coach

### DIFF
--- a/modules/season_statistics.rb
+++ b/modules/season_statistics.rb
@@ -54,35 +54,8 @@ module SeasonStatistics
     @games.select { |g| game_ids << g.game_id if g.season == season }
     @game_teams.select { |g| game_ids.include? g.game_id }
   end
-  #
-  # def team_wins_per_season(season)
-  #   hash = Hash.new(0)
-  #   total_games_per_season(season).each do |g|
-  #     hash[g.team_id] += 1 if g.won == TRUE
-  #   end
-  #   hash
-  # end
-  #
-  # def team_total_games_per_season(season)
-  #   hash = Hash.new(0)
-  #   games.select { |g| g.season == season }.each do |g|
-  #     hash[g.away_team_id] += 1
-  #     hash[g.home_team_id] += 1
-  #   end
-  #   hash
-  # end
 
-  # def win_percentage_per_season(season)
-  #   wins = team_wins_per_season(season)
-  #   totals = team_total_games_per_season(season)
-  #
-  #   totals.each do |season, total|
-  #     totals[season] = (wins[season] / total.to_f * 100).round(2)
-  #   end
-  #   totals
-  # end
-
-  def win_percentage_per_season(season)
+  def coach_win_percentage_per_season(season)
     by_coach = games_in_season(season).group_by { |game| game.head_coach }
     totals = {}
     by_coach.each do |coach, games|
@@ -97,16 +70,16 @@ module SeasonStatistics
   end
 
   def winningest_coach(season)
-    win_percentage_per_season(season).max_by {|k,v| v}.first
+    coach_win_percentage_per_season(season).max_by {|k,v| v}.first
   end
 
   def worst_coach(season)
-    win_percentage_per_season(season).min_by {|k,v| v}.first
+    coach_win_percentage_per_season(season).min_by {|k,v| v}.first
   end
 
   def team_total_shots_per_season(season)
     hash = Hash.new(0)
-    total_games_per_season(season).each do |g|
+    games_in_season(season).each do |g|
       hash[g.team_id] += g.shots
     end
     hash
@@ -114,7 +87,7 @@ module SeasonStatistics
 
   def team_total_goals_per_season(season)
     hash = Hash.new(0)
-    total_games_per_season(season).each do |g|
+    games_in_season(season).each do |g|
       hash[g.team_id] += g.goals
     end
     hash

--- a/modules/season_statistics.rb
+++ b/modules/season_statistics.rb
@@ -83,28 +83,25 @@ module SeasonStatistics
   # end
 
   def win_percentage_per_season(season)
-    by_team = games_in_season(season).group_by { |game| game.team_id }
+    by_coach = games_in_season(season).group_by { |game| game.head_coach }
     totals = {}
-    by_team.each do |team, games|
-      totals[team] = {games: 0, wins: 0}
+    by_coach.each do |coach, games|
+      totals[coach] = {games: 0, wins: 0}
       games.each do |game|
-        totals[team][:games] += 1
-        totals[team][:wins] += 1 if game.won
+        totals[coach][:games] += 1
+        totals[coach][:wins] += 1 if game.won
       end
     end
-    totals.transform_values! { |info| info[:wins].to_f / info[:games]}
+    totals.transform_values! { |info| info[:wins].to_f / info[:games] }
+    totals
   end
 
   def winningest_coach(season)
-    team_id = win_percentage_per_season(season).max_by {|k,v| v}[0]
-    total_games_per_season(season).find { |team| team.team_id == team_id }
-      .head_coach
+    win_percentage_per_season(season).max_by {|k,v| v}.first
   end
 
   def worst_coach(season)
-    worst_team = win_percentage_per_season(season).min_by {|k,v| v}.first
-    @game_teams.find { |team| team.team_id == worst_team }
-      .head_coach
+    win_percentage_per_season(season).min_by {|k,v| v}.first
   end
 
   def team_total_shots_per_season(season)

--- a/test/season_statistics_test.rb
+++ b/test/season_statistics_test.rb
@@ -113,7 +113,7 @@ class SeasonStatisticsTest < Minitest::Test
   end
 
   def test_win_percentage_per_season
-    assert_equal ({"3"=>25.0, "6"=>75.0}), @stat_tracker.win_percentage_per_season("20122013")
+    assert_equal ({"3"=>0.25, "6"=>0.75}), @stat_tracker.win_percentage_per_season("20122013")
   end
 
   def test_team_total_shots_per_season

--- a/test/season_statistics_test.rb
+++ b/test/season_statistics_test.rb
@@ -126,6 +126,14 @@ class SeasonStatisticsTest < Minitest::Test
     assert_equal ({"3"=>14.22, "6"=>11.85}), @stat_tracker.shot_goal_ratio_per_team_per_season("20122013")
   end
 
+  def test_team_hits
+    expected = {
+      '3' => 154,
+      '6' => 139
+    }
+    assert_equal expected, @stat_tracker.team_hits('20122013')
+  end
+
   def test_most_hits
     assert_equal 'Rangers', @stat_tracker.most_hits("20122013")
   end

--- a/test/season_statistics_test.rb
+++ b/test/season_statistics_test.rb
@@ -7,6 +7,7 @@ class SeasonStatisticsTest < Minitest::Test
       teams: './test/dummy_data/dummy_team_info.csv',
       game_teams: './test/dummy_data/dummy_game_teams_stats.csv'
     }
+
     @stat_tracker = StatTracker.from_csv(files)
   end
 
@@ -17,6 +18,7 @@ class SeasonStatisticsTest < Minitest::Test
       teams:  './test/dummy_data/dummy_team_info.csv',
       game_teams: './test/dummy_data/dummy_gt2.csv'
     }
+
     stat_tracker = StatTracker.from_csv(files)
 
     expected = {
@@ -89,6 +91,13 @@ class SeasonStatisticsTest < Minitest::Test
   end
 
   def test_worst_coach
+    rfiles = {
+      game_teams: './data/game_teams_stats.csv',
+      games: './data/game.csv',
+      teams: './data/team_info.csv'
+    }
+
+    stat_tracker = StatTracker.from_csv(rfiles)
     assert_equal "John Tortorella", @stat_tracker.worst_coach("20122013")
   end
 

--- a/test/season_statistics_test.rb
+++ b/test/season_statistics_test.rb
@@ -91,13 +91,6 @@ class SeasonStatisticsTest < Minitest::Test
   end
 
   def test_worst_coach
-    rfiles = {
-      game_teams: './data/game_teams_stats.csv',
-      games: './data/game.csv',
-      teams: './data/team_info.csv'
-    }
-
-    stat_tracker = StatTracker.from_csv(rfiles)
     assert_equal "John Tortorella", @stat_tracker.worst_coach("20122013")
   end
 
@@ -109,20 +102,16 @@ class SeasonStatisticsTest < Minitest::Test
     assert_equal "Bruins", @stat_tracker.least_accurate_team("20122013")
   end
 
-  def test_total_games_per_season
-    assert_equal 8, @stat_tracker.total_games_per_season("20122013").length
+  def test_games_in_season
+    assert_equal 8, @stat_tracker.games_in_season("20122013").length
   end
 
-  def test_team_wins_per_season
-    assert_equal ({"6"=>3, "3"=>1}), @stat_tracker.team_wins_per_season("20122013")
-  end
-
-  def test_team_total_games_per_season
-    assert_equal ({"3"=>4, "6"=>4}), @stat_tracker.team_total_games_per_season("20122013")
-  end
-
-  def test_win_percentage_per_season
-    assert_equal ({"3"=>0.25, "6"=>0.75}), @stat_tracker.win_percentage_per_season("20122013")
+  def test_coach_win_percentage_per_season
+    expected = {
+      "John Tortorella" => 0.25,
+      "Claude Julien" => 0.75
+    }
+    assert_equal expected, @stat_tracker.coach_win_percentage_per_season("20122013")
   end
 
   def test_team_total_shots_per_season


### PR DESCRIPTION
Combined helper methods `team_wins_per_season` and `team_total_games_per_season` into `coach_win_percentage_per_season`, which returns a hash of coach names as keys and their win percentage as a value. `winningest_coach` and `worst_coach` then just find the max or min and return a name.

I was also able to create a `team_hits` helper method that creates a hash of team_id keys, and total hits value. This helped reduce the code of `most_hits` and `fewest_hits` to 2 lines each.

Finally, I implemented the `games_in_season` method to help reduce complexity in `power_play_goal_percentage`. 

I still definitely want to clean up the `win_percent_by_type` helper method to reduce repetition, but everything is working for now, and all of the methods in this module are covered in our own test and pass in rspec.